### PR TITLE
removed xmlns:xacro dependency

### DIFF
--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version="1.6" xmlns:xacro='http://ros.org/wiki/xacro'>
+<sdf version="1.6">
   <model name="iris_demo">
     <include>
       <uri>model://iris_with_standoffs</uri>


### PR DESCRIPTION
in gazebo 11 we are getting the following error when launching the runway world. 
```
Gazebo multi-robot simulator, version 11.2.0
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Msg] Waiting for master.
Gazebo multi-robot simulator, version 11.2.0
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Msg] Waiting for master.
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.1.65
Error [parser.cc:525] parse as sdf version 1.7 failed, should try to parse as old deprecated format
Error Code 4 Msg: Required attribute[xmlns:xacro] in element[sdf] is not specified in SDF.
Error Code 8 Msg: Unable to parse sdf element[sdf]
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.1.65
[Wrn] [Publisher.cc:136] Queue limit reached for topic /gazebo/default/physics/contacts, deleting message. This warning is printed only once.
```

I was able to fix this by simply removing 
```
xmlns:xacro='http://ros.org/wiki/xacro'
```

hope this helps people

