### PR TITLE
remove explicit dep on C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,7 @@ if (UNIX AND NOT APPLE)
   filter_valid_compiler_flags(-fvisibility=hidden -fvisibility-inlines-hidden)
 endif()
 
-set(UNFILTERED_FLAGS "-std=c++14")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VALID_CXX_FLAGS} ${UNFILTERED_FLAGS}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VALID_CXX_FLAGS}")
 
 ###########
 ## Build ##

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -119,6 +119,9 @@ class Control
     this->pid.Init(0.1, 0, 0, 0, 0, 1.0, -1.0);
   }
 
+  /// \brief copy constructor
+  public: Control& operator=(const Control& source) = default;
+
   /// \brief control id / channel
   public: int channel = 0;
 


### PR DESCRIPTION
@khancyr it's been a while. Hope you are doing well!

Some of the users of the Archlinux package of this project have been facing issues and I see that there are also some problems with newer ubuntu versions.

It seems that since this package depends on gazebo/ignition header files, (nwere versions which are written with C++17 in mind), having a force requirement on C++14 prevents successfully building.

This PR removes the forced requirement on C++14, and will default to whatever the gcc versions prefers which should also be in line with the gazebo/ignition versions being utilized for that system.

Most likely closes #47 

I also tried to fix the warnings in that issue but could only resolve one of them. Not sure if the change to fix the other one is needed in the gazebo repo or this one.