### PR TITLE
Resolved the error of drone not spawning in world.

### DIFF
--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version="1.6" xmlns:xacro='http://ros.org/wiki/xacro'>
+<sdf version="1.6">
   <model name="iris_demo">
     <include>
       <uri>model://iris_with_standoffs</uri>


### PR DESCRIPTION
"
Error [parser.cc:525] parse as sdf version 1.7 failed, should try to parse as old deprecated format
Error Code 4 Msg: Required attribute[xmlns:xacro] in element[sdf] is not specified in SDF.
Error Code 8 Msg: Unable to parse sdf element[sdf]
"
The following error had been reolved.